### PR TITLE
configure quarto for website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,3 +22,5 @@ Imports:
 Suggests: 
 	knitr,
     quarto
+Config/Needs/website: quarto
+


### PR DESCRIPTION
This should fix your quarto vignette build. And you shouldn't need quarto in Suggests, or specify a VignetteBuilder in DESCRIPTION.